### PR TITLE
Add Sodium Extra

### DIFF
--- a/minceraft/index.toml
+++ b/minceraft/index.toml
@@ -226,6 +226,11 @@ hash = "d7062507251f577355a3c3e4fd3bc33ea9ac0e74ad0da2c8f0eb6c9b9c182b99"
 metafile = true
 
 [[files]]
+file = "mods/sodium-extra.pw.toml"
+hash = "6b7e9ed619297a29eb6db95f860734144876aa68922de63a05409b65ad8bd163"
+metafile = true
+
+[[files]]
 file = "mods/sodium.pw.toml"
 hash = "350cd01b8b55cea244c2b0ea7bb3c9a6ba873cea4701528c62101c63af6b027a"
 metafile = true

--- a/minceraft/mods/sodium-extra.pw.toml
+++ b/minceraft/mods/sodium-extra.pw.toml
@@ -1,0 +1,13 @@
+name = "Sodium Extra"
+filename = "sodium-extra-0.5.4+mc1.20.1-build.115.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/PtjYWJkn/versions/I7ggF6B5/sodium-extra-0.5.4%2Bmc1.20.1-build.115.jar"
+hash-format = "sha512"
+hash = "ab561186421776d0db506dcbf1a724f80b345be5769ff00aa4327161c79af6e3f353eb65345ce06da30546ffa6b43e1c4a4c41dd246b7e473b131fd727997a85"
+
+[update]
+[update.modrinth]
+mod-id = "PtjYWJkn"
+version = "I7ggF6B5"

--- a/minceraft/pack.toml
+++ b/minceraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "43c6476eb8ec1d7bdd40eb288e6b07329eb84fd327b0089a9f8f45de34248cd3"
+hash = "da30fd8b7658d867c5dc2ce5691cbf98d3c6f8b90310df660bd6ae30299ce5a9"
 
 [versions]
 fabric = "0.16.10"


### PR DESCRIPTION
Very cool yes yes

Github Copilot will take it from here.

This pull request includes changes to add a new mod, "Sodium Extra," to the Minecraft pack configuration. The most important changes are the addition of the new mod's details and the update of the index hash to reflect this addition.

### Addition of new mod:

* [`minceraft/mods/sodium-extra.pw.toml`](diffhunk://#diff-d38c78d7ab95e2b02b4046d1f2a534b4172f5adbb943a1166f8b6e430bba1625R1-R13): Added configuration details for the "Sodium Extra" mod, including its name, filename, side, download URL, hash, and update information.

### Update to index:

* [`minceraft/index.toml`](diffhunk://#diff-553cbbc6f07a51141ae0b3a23528e4f1c28f754cb07ca1eb15480d3713b64668R228-R232): Added a new entry for the "Sodium Extra" mod and updated the hash to include this new mod.
* [`minceraft/pack.toml`](diffhunk://#diff-fa5fbbebe861350f1988410efc6ddc0fb530f6126927d556faccff378c7636c9L9-R9): Updated the hash to reflect the changes in the index file.